### PR TITLE
Fix: Correct base path for GitHub Pages deployment

### DIFF
--- a/build-docs.ps1
+++ b/build-docs.ps1
@@ -67,7 +67,7 @@ $IsPreRelease = $PreReleaseTag -ne ''
 "----------------------------------------"
 "Docs"
 $DocsOutput = $Output
-$Basepath = "/"
+$Basepath = "/tanka-docs-gen/"
 
 
 "Output: $DocsOutput"


### PR DESCRIPTION
The GitHub Pages deployment was resulting in 404 errors due to an incorrect base path configuration. This commit updates the `build-docs.ps1` script to set the `BasePath` variable to `/tanka-docs-gen/`, which is the correct path for this repository's GitHub Pages site.

This change ensures that all assets and links within the generated documentation are resolved correctly, fixing the 404 errors.