### PR TITLE
Fix: Address Git repository discovery and native dependency issues

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,9 @@ jobs:
       - uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          fetch-tags: true
+          repository: ${{ github.repository }}
+          path: .
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4

--- a/build-docs.ps1
+++ b/build-docs.ps1
@@ -67,14 +67,14 @@ $IsPreRelease = $PreReleaseTag -ne ''
 "----------------------------------------"
 "Docs"
 $DocsOutput = $Output
-$Basepath = "/"
+$Basepath = "/tanka-docs-gen/"
 
 
 "Output: $DocsOutput"
 "BasePath: $Basepath"
 
 "Publishing DocsTool..."
-dotnet publish ./src/DocsTool --runtime win-x64 --output ./temp/DocsTool --no-self-contained
+dotnet publish ./src/DocsTool --output ./temp/DocsTool
 EnsureLastExitCode("dotnet publish DocsTool failed")
 
 "Running published DocsTool..."


### PR DESCRIPTION
This commit includes several changes to address errors in the documentation build process:

1.  Modified `build-docs.ps1` to publish `DocsTool` as a framework-dependent application. This resolves errors related to `LibGit2Sharp` failing to load its native dependencies on the Linux GitHub Actions runner, which occurred when `DocsTool` was previously published with a Windows-specific runtime.

2.  Updated the `actions/checkout` step in `.github/workflows/docs.yml` to be more explicit by specifying `repository`, `path: .`, and adding `fetch-tags: true`. This is to ensure the Git repository is fully available and discoverable by `LibGit2Sharp` within `DocsTool`.

3.  Reverted previous diagnostic logging from `build-docs.ps1` and ensured the `BasePath` is correctly set to `/tanka-docs-gen/`.

These changes aim to fix the "System.InvalidOperationException: Could not discover Git repository" error and the preceding native library loading issues.