### PR TITLE
feat: add configurable homepage link support

### DIFF
--- a/src/DocsTool/Definitions/SiteDefinition.cs
+++ b/src/DocsTool/Definitions/SiteDefinition.cs
@@ -21,6 +21,16 @@ namespace Tanka.DocsTool.Definitions
         public string BasePath { get; set; } = "";
 
         public Dictionary<string, Dictionary<string, object>> Extensions { get; set; } = new Dictionary<string, Dictionary<string, object>>();
+
+        public HomepageConfig? Homepage { get; set; }
+    }
+
+    public class HomepageConfig
+    {
+        public string Url { get; set; } = string.Empty;
+        public string Text { get; set; } = "Home";
+        public string Target { get; set; } = "_blank";
+        public bool Enabled { get; set; } = true;
     }
 
     public class BranchDefinition

--- a/src/DocsTool/Definitions/SiteDefinition.cs
+++ b/src/DocsTool/Definitions/SiteDefinition.cs
@@ -22,10 +22,10 @@ namespace Tanka.DocsTool.Definitions
 
         public Dictionary<string, Dictionary<string, object>> Extensions { get; set; } = new Dictionary<string, Dictionary<string, object>>();
 
-        public HomepageConfig? Homepage { get; set; }
+        public HomepageDefinition? Homepage { get; set; }
     }
 
-    public class HomepageConfig
+    public class HomepageDefinition
     {
         public string Url { get; set; } = string.Empty;
         public string Text { get; set; } = "Home";

--- a/src/DocsTool/Resources/default-tanka-docs-wip.yml
+++ b/src/DocsTool/Resources/default-tanka-docs-wip.yml
@@ -23,5 +23,12 @@ extensions:
   - include
   - xref
 
+# Homepage link configuration (optional)
+homepage:
+  url: ""
+  text: "Home"
+  target: "_blank"
+  enabled: false
+
 # Development settings
 base_path: "" 

--- a/src/DocsTool/Resources/default-tanka-docs.yml
+++ b/src/DocsTool/Resources/default-tanka-docs.yml
@@ -21,6 +21,13 @@ ui_bundle: ui-bundle/
 extensions:
   - include
   - xref
+
+# Homepage link configuration (optional)
+homepage:
+  url: ""
+  text: "Home"
+  target: "_blank"
+  enabled: false
   
 # Development settings (override in tanka-docs-wip.yml for WIP builds)
 base_path: "" 

--- a/tanka-docs-wip.yml
+++ b/tanka-docs-wip.yml
@@ -3,6 +3,11 @@ title: "Tanka Docs Generator - WIP"
 index_page: xref://root@HEAD:index.md
 output_path: "gh-pages"
 build_path: "_build"
+homepage:
+  url: "https://github.com/pekkah/tanka-docs-gen"
+  text: "GitHub"
+  target: "_blank"
+  enabled: true
 branches:
   HEAD:
     input_path:

--- a/tanka-docs.yml
+++ b/tanka-docs.yml
@@ -3,6 +3,11 @@ title: "Tanka Docs Generator"
 index_page: xref://root@master:index.md
 output_path: "gh-pages"
 build_path: "_build"
+homepage:
+  url: "https://github.com/pekkah/tanka-docs-gen"
+  text: "GitHub"
+  target: "_blank"
+  enabled: true
 branches:
   master:
     input_path:

--- a/ui-bundle/article.hbs
+++ b/ui-bundle/article.hbs
@@ -164,9 +164,11 @@
                     {{/sections}}
                 </ul>
                 <ul class="navbar-nav ms-auto">
+                    {{#if Site.Definition.Homepage.Enabled}}
                     <li class="nav-item">
-                        <a class="nav-link" href="https://github.com/pekkah/tanka-docs-gen" target="_blank" rel="noopener">GitHub</a>
+                        <a class="nav-link" href="{{Site.Definition.Homepage.Url}}" target="{{Site.Definition.Homepage.Target}}" rel="noopener">{{Site.Definition.Homepage.Text}}</a>
                     </li>
+                    {{/if}}
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                             {{Section.Version}}


### PR DESCRIPTION
Replace hardcoded GitHub link in navigation with configurable homepage link.

**Key Changes:**
- Add HomepageConfig class with Url, Text, Target, and Enabled properties
- Update SiteDefinition to include Homepage property
- Replace hardcoded link in article.hbs template with conditional rendering
- Update sample configurations to demonstrate homepage functionality

**Configuration Example:**
```yaml
homepage:
  url: "https://github.com/myorg/my-project"
  text: "GitHub"
  target: "_blank"
  enabled: true
```

**Backward Compatibility:**
- Homepage link is optional and disabled by default when not configured
- Existing sites continue to work without changes

Fixes #235

Generated with [Claude Code](https://claude.ai/code)