### PR TITLE
Fix build failures returning exit code 0 (Issue #251)

### DIFF
--- a/src/DocsTool/Program.cs
+++ b/src/DocsTool/Program.cs
@@ -39,4 +39,4 @@ app.Configure(config =>
     config.AddCommand<InitCommand>("init");
 });
 
-await app.RunAsync(args);
+return await app.RunAsync(args);


### PR DESCRIPTION
## Summary
- Fix build command not returning proper exit codes to CI/CD systems
- The BuildSiteCommand was correctly returning -1 for failures, but Program.cs wasn't returning the exit code from the CLI framework
- Simple one-line fix: `return await app.RunAsync(args);`

## Root Cause
The Program.cs was calling `await app.RunAsync(args);` without returning the result, causing all builds to exit with code 0 regardless of success or failure.

## Solution
Changed Program.cs line 42 from:
```csharp
await app.RunAsync(args);
```
to:
```csharp
return await app.RunAsync(args);
```

## Test Plan
- [x] Verified build command returns exit code 255 (-1) for missing config files
- [x] Verified build command returns exit code 0 for successful builds
- [x] All existing tests pass
- [x] CI/CD systems can now properly detect build failures

## Impact
- CI/CD pipelines will now properly fail when documentation builds fail
- Resolves the issue where broken documentation was being deployed to production
- No workaround needed anymore for checking output files manually

Fixes #251

🤖 Generated with [Claude Code](https://claude.ai/code)