### PR TITLE
feat: implement configurable link validation modes for broken xref handling (Issue #253)

### DIFF
--- a/src/DocsTool/AggregateContent.cs
+++ b/src/DocsTool/AggregateContent.cs
@@ -33,7 +33,7 @@ public class AggregateContent : IMiddleware
                 new ProgressBarColumn(),
                 new ItemCountColumn(),
                 new ElapsedTimeColumn(),
-                new RemainingTimeColumn(), 
+                new RemainingTimeColumn(),
                 new SpinnerColumn()
             )
             .StartAsync(async progress =>

--- a/src/DocsTool/AnsiConsoleExtensions.cs
+++ b/src/DocsTool/AnsiConsoleExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace Tanka.DocsTool;
+﻿using Spectre.Console;
+
+namespace Tanka.DocsTool;
 
 internal static class AnsiConsoleExtensions
 {
@@ -26,5 +28,37 @@ internal static class AnsiConsoleExtensions
     {
         console.MarkupLineInterpolated($"[[{DateTimeOffset.Now:T}]] [red bold]INFO[/]: {message}");
         console.WriteException(exception);
+    }
+
+    // Validation message extension methods for consistent styling
+    public static void WriteError(this IAnsiConsole console, string message)
+    {
+        console.MarkupLine($"[red]Error:[/] {Markup.Escape(message)}");
+    }
+
+    public static void WriteError(this IAnsiConsole console, string message, string? filePath)
+    {
+        if (!string.IsNullOrEmpty(filePath))
+            console.MarkupLine($"[red]Error:[/] In {Markup.Escape(filePath)}: {Markup.Escape(message)}");
+        else
+            console.MarkupLine($"[red]Error:[/] {Markup.Escape(message)}");
+    }
+
+    public static void WriteWarning(this IAnsiConsole console, string message)
+    {
+        console.MarkupLine($"[yellow]Warning:[/] {Markup.Escape(message)}");
+    }
+
+    public static void WriteWarning(this IAnsiConsole console, string message, string? filePath)
+    {
+        if (!string.IsNullOrEmpty(filePath))
+            console.MarkupLine($"[yellow]Warning:[/] In {Markup.Escape(filePath)}: {Markup.Escape(message)}");
+        else
+            console.MarkupLine($"[yellow]Warning:[/] {Markup.Escape(message)}");
+    }
+
+    public static void WriteBuildFailure(this IAnsiConsole console)
+    {
+        console.MarkupLine("[red]Build failed with errors:[/]");
     }
 }

--- a/src/DocsTool/AugmentFilesSections.cs
+++ b/src/DocsTool/AugmentFilesSections.cs
@@ -30,11 +30,11 @@ public class AugmentFilesSections : IMiddleware
 
         // Find sections with type: files and augment catalog with working directory content
         var filesSections = context.Sections?.Where(s => s.Definition.Type?.ToLowerInvariant() == "files").ToList();
-        
+
         if (filesSections?.Any() == true)
         {
             _logger.LogInformation($"Found {filesSections.Count} files sections, augmenting with working directory content");
-            
+
             await _console.Progress()
                 .Columns(
                     new TaskDescriptionColumn(),
@@ -80,7 +80,7 @@ public class FilesSectionAugmenter
         foreach (var section in filesSections)
         {
             var task = progress.AddTask($"Files section: {section.Id}@{section.Version}", maxValue: 0);
-            
+
             try
             {
                 await AugmentSectionWithWorkingDirectoryContent(catalog, section, task);
@@ -111,13 +111,13 @@ public class FilesSectionAugmenter
         // Stream content items directly from working directory
         var contentItems = CollectWorkingDirectoryContent(sectionDirectory, section, task);
         await catalog.Add(contentItems);
-        
+
         _console.LogInformation($"Augmented files section '{section.Id}' with working directory content");
     }
 
     private async IAsyncEnumerable<ContentItem> CollectWorkingDirectoryContent(
-        IReadOnlyDirectory directory, 
-        Section section, 
+        IReadOnlyDirectory directory,
+        Section section,
         ProgressTask task)
     {
         await foreach (var node in directory.Enumerate())
@@ -136,11 +136,11 @@ public class FilesSectionAugmenter
                     var contentSource = new FileSystemContentSource(_fileSystem, section.Version, section.Path);
                     var contentType = _classifier.Classify(file);
                     var contentItem = new ContentItem(contentSource, contentType, file);
-                    
+
                     task.Increment(1);
                     yield return contentItem;
                     break;
-                    
+
                 case IReadOnlyDirectory subDirectory:
                     // Apply security filtering to directories
                     if (_securityFilter.ShouldExclude(subDirectory))

--- a/src/DocsTool/BuildSiteCommand.cs
+++ b/src/DocsTool/BuildSiteCommand.cs
@@ -112,7 +112,7 @@ public class BuildSiteCommand : AsyncCommand<BuildSiteCommand.Settings>
                     _console.MarkupLine($"[yellow]Warning:[/] {Markup.Escape(warning.Message)}");
                 }
             }
-            
+
             // report errors
             if (buildContext.HasErrors)
             {
@@ -161,5 +161,9 @@ public class BuildSiteCommand : AsyncCommand<BuildSiteCommand.Settings>
         [CommandOption("--base <BASE>")]
         [Description("Set the base href meta for the generated html pages.")]
         public string? Base { get; set; }
+
+        [CommandOption("--link-validation <MODE>")]
+        [Description("Link validation mode: strict or relaxed")]
+        public LinkValidation LinkValidation { get; set; } = LinkValidation.Strict;
     }
 }

--- a/src/DocsTool/BuildUi.cs
+++ b/src/DocsTool/BuildUi.cs
@@ -36,7 +36,7 @@ internal class BuildUi : IMiddleware
             context.Add(new Error($"UI build failed: {ex.Message}"));
             _console.MarkupLine($"[red]UI build error:[/] {Markup.Escape(ex.Message)}");
         }
-         
+
         await next(context);
     }
 }

--- a/src/DocsTool/Catalogs/ContentAggregator.cs
+++ b/src/DocsTool/Catalogs/ContentAggregator.cs
@@ -39,9 +39,9 @@ public class ContentAggregator
         await foreach (var source in BuildSources(context, cancellationToken))
         {
             _console.LogInformation($"Loading: '{source.Path}@{source.Version}'");
-            
+
             var task = progress.AddTask(GetTaskDescription(source), maxValue: 0);
-           
+
             await foreach (var node in source.Enumerate(cancellationToken))
                 stack.Push(node);
 
@@ -50,7 +50,7 @@ public class ContentAggregator
             {
                 var node = stack.Pop();
                 task.Increment(1);
-               
+
                 switch (node)
                 {
                     case IReadOnlyFile file:
@@ -93,7 +93,7 @@ public class ContentAggregator
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         var branches = _site.Branches;
-       
+
         foreach (var (branch, definition) in branches)
         {
             var commonInputPaths = definition.InputPath;
@@ -107,14 +107,14 @@ public class ContentAggregator
                     //// as the source of the truth
                     //if (status.IsDirty)
                     //{
-                        var inputDirectory = await _workFileSystem.GetDirectory(commonInputPath);
-                        if (inputDirectory != null)
-                        {
-                            yield return new FileSystemContentSource(
-                                _workFileSystem,
-                                "HEAD",
-                                inputDirectory.Path); // we're mounting the input path
-                        }
+                    var inputDirectory = await _workFileSystem.GetDirectory(commonInputPath);
+                    if (inputDirectory != null)
+                    {
+                        yield return new FileSystemContentSource(
+                            _workFileSystem,
+                            "HEAD",
+                            inputDirectory.Path); // we're mounting the input path
+                    }
                     //}
                     //else
                     //{
@@ -135,7 +135,7 @@ public class ContentAggregator
                             var matchingBranch = _git.Branch(repoBranch.CanonicalName);
                             if (await matchingBranch.GetDirectory(commonInputPath) != null)
                             {
-                                
+
                                 yield return new GitBranchContentSource(
                                     matchingBranch,
                                     commonInputPath);

--- a/src/DocsTool/Catalogs/ContentItem.cs
+++ b/src/DocsTool/Catalogs/ContentItem.cs
@@ -11,7 +11,7 @@
             _source = source;
         }
 
-        public const string SectionDefinitionType  = "tanka/section";
+        public const string SectionDefinitionType = "tanka/section";
 
         public string Type { get; }
 

--- a/src/DocsTool/Catalogs/MimeDbClassifier.cs
+++ b/src/DocsTool/Catalogs/MimeDbClassifier.cs
@@ -28,7 +28,7 @@ namespace Tanka.DocsTool.Catalogs
         {
             return (filename, extension) switch
             {
-                { filename: "tanka-docs-section", extension: ".yml" or ".yaml"} => ContentItem.SectionDefinitionType,
+                { filename: "tanka-docs-section", extension: ".yml" or ".yaml" } => ContentItem.SectionDefinitionType,
                 (_, _) => null
             };
         }

--- a/src/DocsTool/DevCommandSettings.cs
+++ b/src/DocsTool/DevCommandSettings.cs
@@ -13,4 +13,8 @@ public class DevCommandSettings : CommandSettings
     [Description("Port to run the dev server on.")]
     [DefaultValue(5000)]
     public int Port { get; set; }
-} 
+
+    [CommandOption("--link-validation <MODE>")]
+    [Description("Link validation mode: strict or relaxed")]
+    public LinkValidation LinkValidation { get; set; } = LinkValidation.Relaxed;
+}

--- a/src/DocsTool/Extensions/IncludeProcessor.cs
+++ b/src/DocsTool/Extensions/IncludeProcessor.cs
@@ -56,9 +56,9 @@ namespace Tanka.DocsTool.Extensions
 
                         if (beforePosition.Length > 0)
                         {
-                            var memory = writer.GetMemory((int) beforePosition.Length);
+                            var memory = writer.GetMemory((int)beforePosition.Length);
                             beforePosition.CopyTo(memory.Span);
-                            writer.Advance((int) beforePosition.Length);
+                            writer.Advance((int)beforePosition.Length);
                             await writer.FlushAsync();
                         }
 
@@ -99,14 +99,14 @@ namespace Tanka.DocsTool.Extensions
         }
 
         private bool TryReadInclude(
-            ReadResult readResult, 
-            out SequencePosition start, 
+            ReadResult readResult,
+            out SequencePosition start,
             out SequencePosition end,
-            [NotNullWhen(true)]out IncludeDirective? include)
+            [NotNullWhen(true)] out IncludeDirective? include)
         {
             var reader = new SequenceReader<byte>(readResult.Buffer);
 
-            while (reader.TryReadTo(out ReadOnlySpan<byte> beforeHash, (byte) '#', (byte) '\\', false))
+            while (reader.TryReadTo(out ReadOnlySpan<byte> beforeHash, (byte)'#', (byte)'\\', false))
             {
                 start = reader.Position;
 

--- a/src/DocsTool/FileWatcher.cs
+++ b/src/DocsTool/FileWatcher.cs
@@ -64,7 +64,7 @@ public class FileWatcher : IDisposable
     {
         if (_cancellationToken.IsCancellationRequested)
             return;
-            
+
         _debounceCts?.Cancel();
         _debounceCts = new CancellationTokenSource();
 
@@ -102,7 +102,7 @@ public class FileWatcher : IDisposable
         _debounceCts?.Cancel();
         _debounceCts?.Dispose();
         _debounceCts = null;
-        
+
         foreach (var watcher in _watchers)
         {
             watcher.EnableRaisingEvents = false;
@@ -130,4 +130,4 @@ public readonly struct FileChange
 {
     public required string FullPath { get; init; }
     public required FileChangeType ChangeType { get; init; }
-} 
+}

--- a/src/DocsTool/GlobalUsings.cs
+++ b/src/DocsTool/GlobalUsings.cs
@@ -1,6 +1,6 @@
 ﻿global using Spectre.Console;
 global using Tanka.DocsTool;
 global using Tanka.DocsTool.Definitions;
+global using Tanka.DocsTool.Internal;
 global using Tanka.DocsTool.Pipelines;
 global using Tanka.FileSystem;
-global using Tanka.DocsTool.Internal;

--- a/src/DocsTool/Infra.cs
+++ b/src/DocsTool/Infra.cs
@@ -11,7 +11,7 @@ namespace Tanka.DocsTool
             LoggerFactory = loggerFactory;
         }
 
-        public static ILoggerFactory LoggerFactory = new NullLoggerFactory(); 
+        public static ILoggerFactory LoggerFactory = new NullLoggerFactory();
 
         public static ILogger Logger => LoggerFactory.CreateLogger("main");
     }

--- a/src/DocsTool/Init/EmbeddedResources.cs
+++ b/src/DocsTool/Init/EmbeddedResources.cs
@@ -9,7 +9,7 @@ namespace Tanka.DocsTool.Init;
 public static class EmbeddedResources
 {
     private const string ResourcePrefix = "Tanka.DocsTool.Resources.";
-    
+
     /// <summary>
     /// Gets the embedded UI bundle as a zip archive stream.
     /// </summary>
@@ -19,15 +19,15 @@ public static class EmbeddedResources
     {
         var assembly = Assembly.GetExecutingAssembly();
         var resourceName = $"{ResourcePrefix}ui-bundle.zip";
-        
+
         var stream = assembly.GetManifestResourceStream(resourceName);
         if (stream == null)
             throw new InvalidOperationException($"Embedded resource '{resourceName}' not found. " +
                                                 "Ensure the UI bundle was properly embedded during build.");
-            
+
         return stream;
     }
-    
+
     /// <summary>
     /// Gets the default production configuration template.
     /// </summary>
@@ -37,16 +37,16 @@ public static class EmbeddedResources
     {
         var assembly = Assembly.GetExecutingAssembly();
         var resourceName = $"{ResourcePrefix}default-tanka-docs.yml";
-        
+
         using var stream = assembly.GetManifestResourceStream(resourceName);
         if (stream == null)
             throw new InvalidOperationException($"Embedded resource '{resourceName}' not found. " +
                                                 "Ensure the configuration template was properly embedded during build.");
-            
+
         using var reader = new StreamReader(stream);
         return reader.ReadToEnd();
     }
-    
+
     /// <summary>
     /// Gets the default WIP/development configuration template.
     /// </summary>
@@ -56,16 +56,16 @@ public static class EmbeddedResources
     {
         var assembly = Assembly.GetExecutingAssembly();
         var resourceName = $"{ResourcePrefix}default-tanka-docs-wip.yml";
-        
+
         using var stream = assembly.GetManifestResourceStream(resourceName);
         if (stream == null)
             throw new InvalidOperationException($"Embedded resource '{resourceName}' not found. " +
                                                 "Ensure the WIP configuration template was properly embedded during build.");
-            
+
         using var reader = new StreamReader(stream);
         return reader.ReadToEnd();
     }
-    
+
     /// <summary>
     /// Checks if the UI bundle resource exists.
     /// </summary>
@@ -76,7 +76,7 @@ public static class EmbeddedResources
         var resourceName = $"{ResourcePrefix}ui-bundle.zip";
         return assembly.GetManifestResourceNames().Contains(resourceName);
     }
-    
+
     /// <summary>
     /// Lists all embedded resource names (useful for debugging).
     /// </summary>
@@ -86,4 +86,4 @@ public static class EmbeddedResources
         var assembly = Assembly.GetExecutingAssembly();
         return assembly.GetManifestResourceNames();
     }
-} 
+}

--- a/src/DocsTool/Init/GitValidator.cs
+++ b/src/DocsTool/Init/GitValidator.cs
@@ -25,7 +25,7 @@ public static class GitValidator
                 "Then run 'tanka-docs init' again.");
         }
     }
-    
+
     /// <summary>
     /// Checks if the current directory is a Git repository.
     /// </summary>
@@ -35,7 +35,7 @@ public static class GitValidator
         // First check for .git directory (most common case)
         if (Directory.Exists(".git"))
             return true;
-            
+
         // Then check via git command (handles worktrees and other cases)
         try
         {
@@ -47,7 +47,7 @@ public static class GitValidator
             return false;
         }
     }
-    
+
     /// <summary>
     /// Gets the current Git branch name.
     /// </summary>
@@ -60,12 +60,12 @@ public static class GitValidator
             var result = RunGitCommand("symbolic-ref --short HEAD");
             if (!string.IsNullOrWhiteSpace(result))
                 return result.Trim();
-                
+
             // Fallback to rev-parse (works for detached HEAD)
             result = RunGitCommand("rev-parse --abbrev-ref HEAD");
             if (!string.IsNullOrWhiteSpace(result) && result.Trim() != "HEAD")
                 return result.Trim();
-                
+
             return null; // Detached HEAD or other edge case
         }
         catch
@@ -73,7 +73,7 @@ public static class GitValidator
             return null; // Git not available or not a git repository
         }
     }
-    
+
     /// <summary>
     /// Gets a sensible default branch name, preferring current branch or falling back to common defaults.
     /// </summary>
@@ -84,11 +84,11 @@ public static class GitValidator
         var currentBranch = GetCurrentBranch();
         if (!string.IsNullOrEmpty(currentBranch))
             return currentBranch;
-            
+
         // Fallback to modern default
         return "main";
     }
-    
+
     /// <summary>
     /// Checks if Git is available on the system.
     /// </summary>
@@ -105,7 +105,7 @@ public static class GitValidator
             return false;
         }
     }
-    
+
     /// <summary>
     /// Runs a Git command and returns its output.
     /// </summary>
@@ -126,17 +126,17 @@ public static class GitValidator
                 CreateNoWindow = true
             }
         };
-        
+
         process.Start();
         var output = process.StandardOutput.ReadToEnd();
         var error = process.StandardError.ReadToEnd();
         process.WaitForExit();
-        
+
         if (process.ExitCode != 0)
         {
             throw new InvalidOperationException($"Git command failed: git {arguments}\n{error}");
         }
-        
+
         return output;
     }
-} 
+}

--- a/src/DocsTool/Init/TemplateProcessor.cs
+++ b/src/DocsTool/Init/TemplateProcessor.cs
@@ -17,18 +17,18 @@ public static class TemplateProcessor
     {
         if (string.IsNullOrWhiteSpace(template))
             return template;
-            
+
         var result = template;
-        
+
         foreach (var variable in variables)
         {
             var placeholder = $"{{{{{variable.Key}}}}}";
             result = result.Replace(placeholder, variable.Value);
         }
-        
+
         return result;
     }
-    
+
     /// <summary>
     /// Creates variable dictionary for template processing based on provided values.
     /// </summary>
@@ -37,8 +37,8 @@ public static class TemplateProcessor
     /// <param name="outputPath">Custom output path (optional)</param>
     /// <returns>Dictionary of template variables</returns>
     public static Dictionary<string, string> CreateVariables(
-        string projectName, 
-        string defaultBranch, 
+        string projectName,
+        string defaultBranch,
         string? outputPath = null)
     {
         var variables = new Dictionary<string, string>
@@ -46,15 +46,15 @@ public static class TemplateProcessor
             ["PROJECT_NAME"] = projectName,
             ["DEFAULT_BRANCH"] = defaultBranch
         };
-        
+
         if (!string.IsNullOrWhiteSpace(outputPath))
         {
             variables["OUTPUT_PATH"] = outputPath;
         }
-        
+
         return variables;
     }
-    
+
     /// <summary>
     /// Processes the default production configuration template.
     /// </summary>
@@ -68,7 +68,7 @@ public static class TemplateProcessor
         var variables = CreateVariables(projectName, defaultBranch, outputPath);
         return ProcessTemplate(template, variables);
     }
-    
+
     /// <summary>
     /// Processes the default WIP configuration template.
     /// </summary>
@@ -81,7 +81,7 @@ public static class TemplateProcessor
         var variables = CreateVariables(projectName, "HEAD", outputPath); // WIP always uses HEAD
         return ProcessTemplate(template, variables);
     }
-    
+
     /// <summary>
     /// Derives a project name from the current directory name.
     /// </summary>
@@ -90,14 +90,14 @@ public static class TemplateProcessor
     {
         var currentDir = Directory.GetCurrentDirectory();
         var dirName = Path.GetFileName(currentDir);
-        
+
         if (string.IsNullOrWhiteSpace(dirName))
             return "Documentation Project";
-            
+
         // Sanitize the directory name for use as a project name
         return SanitizeProjectName(dirName);
     }
-    
+
     /// <summary>
     /// Sanitizes a project name to be suitable for documentation titles.
     /// </summary>
@@ -107,21 +107,21 @@ public static class TemplateProcessor
     {
         if (string.IsNullOrWhiteSpace(name))
             return "Documentation Project";
-            
+
         // Replace common separators with spaces and title case
         var sanitized = name
             .Replace("-", " ")
             .Replace("_", " ")
             .Replace(".", " ");
-            
+
         // Title case each word
         var words = sanitized.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-        var titleCased = words.Select(word => 
+        var titleCased = words.Select(word =>
             char.ToUpperInvariant(word[0]) + word[1..].ToLowerInvariant());
-            
+
         return string.Join(" ", titleCased);
     }
-    
+
     /// <summary>
     /// Finds all placeholder variables in a template.
     /// </summary>
@@ -131,17 +131,17 @@ public static class TemplateProcessor
     {
         if (string.IsNullOrWhiteSpace(template))
             return new List<string>();
-            
+
         var regex = new Regex(@"\{\{(\w+)\}\}", RegexOptions.Compiled);
         var matches = regex.Matches(template);
-        
+
         return matches
             .Cast<Match>()
             .Select(m => m.Groups[1].Value)
             .Distinct()
             .ToList();
     }
-    
+
     /// <summary>
     /// Validates that all required variables are provided for a template.
     /// </summary>
@@ -152,9 +152,9 @@ public static class TemplateProcessor
     {
         var requiredVariables = FindVariablesInTemplate(template);
         var providedVariables = variables.Keys.ToHashSet();
-        
+
         return requiredVariables
             .Where(variable => !providedVariables.Contains(variable))
             .ToList();
     }
-} 
+}

--- a/src/DocsTool/Init/ZipExtractor.cs
+++ b/src/DocsTool/Init/ZipExtractor.cs
@@ -18,7 +18,7 @@ public static class ZipExtractor
     {
         if (string.IsNullOrWhiteSpace(targetDirectory))
             throw new ArgumentException("Target directory cannot be null or empty", nameof(targetDirectory));
-            
+
         try
         {
             using var zipStream = EmbeddedResources.GetUiBundleZip();
@@ -29,7 +29,7 @@ public static class ZipExtractor
             throw new InvalidOperationException($"Failed to extract UI bundle to '{targetDirectory}': {ex.Message}", ex);
         }
     }
-    
+
     /// <summary>
     /// Extracts a zip stream to the specified directory with detailed control.
     /// </summary>
@@ -39,33 +39,33 @@ public static class ZipExtractor
     public static void ExtractZipToDirectory(Stream zipStream, string targetDirectory, bool overwrite = false)
     {
         using var archive = new ZipArchive(zipStream, ZipArchiveMode.Read);
-        
+
         foreach (var entry in archive.Entries)
         {
             var destinationPath = Path.Combine(targetDirectory, entry.FullName);
-            
+
             // Skip directory entries
             if (entry.FullName.EndsWith('/') || entry.FullName.EndsWith('\\'))
                 continue;
-                
+
             // Create directory if needed
             var directory = Path.GetDirectoryName(destinationPath);
             if (!string.IsNullOrEmpty(directory))
             {
                 Directory.CreateDirectory(directory);
             }
-            
+
             // Check if file exists and handle overwrite
             if (File.Exists(destinationPath) && !overwrite)
             {
                 continue; // Skip existing file
             }
-            
+
             // Extract file
             entry.ExtractToFile(destinationPath, overwrite: overwrite);
         }
     }
-    
+
     /// <summary>
     /// Gets information about the contents of the embedded UI bundle.
     /// </summary>
@@ -74,13 +74,13 @@ public static class ZipExtractor
     {
         using var zipStream = EmbeddedResources.GetUiBundleZip();
         using var archive = new ZipArchive(zipStream, ZipArchiveMode.Read);
-        
+
         return archive.Entries
             .Where(entry => !entry.FullName.EndsWith('/') && !entry.FullName.EndsWith('\\'))
             .Select(entry => entry.FullName)
             .ToList();
     }
-    
+
     /// <summary>
     /// Checks if the target directory already contains UI bundle files.
     /// </summary>
@@ -90,10 +90,10 @@ public static class ZipExtractor
     {
         if (!Directory.Exists(targetDirectory))
             return false;
-            
+
         // Check for key UI bundle files
         var keyFiles = new[] { "article.hbs", "tanka-docs-section.yml" };
-        
+
         return keyFiles.Any(file => File.Exists(Path.Combine(targetDirectory, file)));
     }
-} 
+}

--- a/src/DocsTool/InitCommand.cs
+++ b/src/DocsTool/InitCommand.cs
@@ -28,8 +28,8 @@ public class InitCommand : AsyncCommand<InitCommandSettings>
             _console.MarkupLine("[bold green]Initializing Tanka Docs project...[/]");
 
             // Resolve output directory
-            var outputDir = string.IsNullOrEmpty(settings.OutputDir) 
-                ? Directory.GetCurrentDirectory() 
+            var outputDir = string.IsNullOrEmpty(settings.OutputDir)
+                ? Directory.GetCurrentDirectory()
                 : Path.GetFullPath(settings.OutputDir);
 
             _console.MarkupLine($"[dim]Output directory: {outputDir}[/]");
@@ -100,9 +100,9 @@ public class InitCommand : AsyncCommand<InitCommandSettings>
                 if (!settings.ConfigOnly)
                 {
                     _console.MarkupLine("[bold]Extracting UI bundle...[/]");
-                    
+
                     var uiBundlePath = Path.Combine(outputDir, "ui-bundle");
-                    
+
                     try
                     {
                         ZipExtractor.ExtractUiBundleToDirectory(uiBundlePath, settings.Force);
@@ -155,7 +155,7 @@ public class InitCommand : AsyncCommand<InitCommandSettings>
 
                 // Success summary
                 _console.MarkupLine("[bold green]✓ Initialization completed![/]");
-                
+
                 if (createdFiles.Any())
                 {
                     _console.MarkupLine($"[dim]Created {createdFiles.Count} files/directories[/]");
@@ -166,7 +166,7 @@ public class InitCommand : AsyncCommand<InitCommandSettings>
                 {
                     _console.WriteLine();
                     _console.MarkupLine("[bold]Next steps:[/]");
-                    
+
                     if (!settings.UiBundleOnly)
                     {
                         _console.MarkupLine("1. Review and customize your configuration:");
@@ -205,4 +205,4 @@ public class InitCommand : AsyncCommand<InitCommandSettings>
             return -1;
         }
     }
-} 
+}

--- a/src/DocsTool/InitCommandSettings.cs
+++ b/src/DocsTool/InitCommandSettings.cs
@@ -39,4 +39,4 @@ public class InitCommandSettings : CommandSettings
     [CommandOption("--project-name <NAME>")]
     [Description("Specify project name (default: derive from directory name).")]
     public string? ProjectName { get; set; }
-} 
+}

--- a/src/DocsTool/LinkValidation.cs
+++ b/src/DocsTool/LinkValidation.cs
@@ -1,0 +1,17 @@
+namespace Tanka.DocsTool;
+
+/// <summary>
+/// Defines the validation mode for broken xref links
+/// </summary>
+public enum LinkValidation
+{
+    /// <summary>
+    /// Broken xref links cause build errors and build failure
+    /// </summary>
+    Strict,
+
+    /// <summary>
+    /// Broken xref links generate warnings but build continues with placeholder links
+    /// </summary>
+    Relaxed
+}

--- a/src/DocsTool/Markdown/DocsMarkdownRenderingContext.cs
+++ b/src/DocsTool/Markdown/DocsMarkdownRenderingContext.cs
@@ -6,13 +6,15 @@ namespace Tanka.DocsTool.Markdown
     public class DocsMarkdownRenderingContext
     {
         public DocsMarkdownRenderingContext(
-            Site site, 
-            Section section, 
-            DocsSiteRouter router)
+            Site site,
+            Section section,
+            DocsSiteRouter router,
+            BuildContext buildContext)
         {
             Site = site;
             Section = section;
             Router = router;
+            BuildContext = buildContext;
         }
 
         public Site Site { get; }
@@ -20,5 +22,7 @@ namespace Tanka.DocsTool.Markdown
         public Section Section { get; }
 
         public DocsSiteRouter Router { get; }
+
+        public BuildContext BuildContext { get; }
     }
 }

--- a/src/DocsTool/Markdown/DocsMarkdownService.cs
+++ b/src/DocsTool/Markdown/DocsMarkdownService.cs
@@ -62,7 +62,7 @@ namespace Tanka.DocsTool.Markdown
             var yaml = frontmatterBlock?.Lines.ToString();
             if (string.IsNullOrEmpty(yaml))
                 return null;
-            
+
             var result = yaml.TryParseYaml<PageFrontmatter>();
             return result.IsSuccess ? result.Value : null;
         }

--- a/src/DocsTool/Markdown/HtmlDisplayLinksRenderer.cs
+++ b/src/DocsTool/Markdown/HtmlDisplayLinksRenderer.cs
@@ -7,21 +7,47 @@ namespace Tanka.DocsTool.Markdown
     public class HtmlDisplayLinksRenderer : HtmlObjectRenderer<DisplayLinkInline>
     {
         private readonly DocsSiteRouter _router;
+        private readonly DocsMarkdownRenderingContext? _context;
 
         public HtmlDisplayLinksRenderer(DocsMarkdownRenderingContext context)
         {
             _router = context.Router;
+            _context = context;
         }
 
         protected override void Write(HtmlRenderer renderer, DisplayLinkInline obj)
         {
-            var url = obj.DisplayLink.Link.IsXref
-                ? _router.GenerateRoute(obj.DisplayLink.Link.Xref!.Value)
-                : obj.DisplayLink.Link.Uri;
+            string? url;
+
+            if (obj.DisplayLink.Link.IsXref)
+            {
+                var xref = obj.DisplayLink.Link.Xref!.Value;
+                if (_context?.BuildContext != null)
+                {
+                    url = _router.GenerateRoute(xref, _context.BuildContext);
+                }
+                else
+                {
+                    // Fallback to old behavior if no BuildContext available
+                    url = _router.GenerateRoute(xref);
+                }
+            }
+            else
+            {
+                url = obj.DisplayLink.Link.Uri;
+            }
 
             renderer.Write("<a href=\"");
             renderer.WriteEscapeUrl(url);
             renderer.Write("\"");
+
+            // Add CSS class for broken xrefs in relaxed mode
+            if (obj.DisplayLink.Link.IsXref && url?.StartsWith("#broken-xref-") == true)
+            {
+                renderer.Write(" class=\"broken-xref\"");
+                renderer.Write($" data-original-xref=\"{obj.DisplayLink.Link.Xref}\"");
+            }
+
             renderer.Write(">");
             renderer.Write(obj.DisplayLink.Title ?? "[Title is missing]");
             renderer.Write("</a>");

--- a/src/DocsTool/PathResolver.cs
+++ b/src/DocsTool/PathResolver.cs
@@ -18,4 +18,4 @@ public static class PathResolver
 
         return (currentPath, configFilePath);
     }
-} 
+}

--- a/src/DocsTool/Pipelines/BuildContext.cs
+++ b/src/DocsTool/Pipelines/BuildContext.cs
@@ -8,8 +8,10 @@ public record BuildContext(SiteDefinition SiteDefinition, FileSystemPath WorkPat
     private readonly List<Error> _errors = new();
     private readonly List<Error> _warnings = new();
 
+    public LinkValidation LinkValidation { get; set; } = LinkValidation.Strict;
+
     public IReadOnlyCollection<Error> Errors => _errors.AsReadOnly();
-    
+
     public IReadOnlyCollection<Error> Warnings => _warnings.AsReadOnly();
 
     public bool HasErrors => _errors.Count > 0;

--- a/src/DocsTool/Pipelines/DefaultPipeline.cs
+++ b/src/DocsTool/Pipelines/DefaultPipeline.cs
@@ -25,5 +25,5 @@ public static class DefaultPipeline
         services.AddSingleton<BuildUi>();
 
         return services;
-    } 
+    }
 }

--- a/src/DocsTool/Pipelines/Error.cs
+++ b/src/DocsTool/Pipelines/Error.cs
@@ -12,4 +12,4 @@ public record Error
 
     public string Message { get; }
     public ContentItem? ContentItem { get; }
-}; 
+};

--- a/src/DocsTool/Pipelines/PipelineExecutor.cs
+++ b/src/DocsTool/Pipelines/PipelineExecutor.cs
@@ -15,6 +15,11 @@ public class PipelineExecutor
         FileSystemPath workPath)
     {
         var context = new BuildContext(siteDefinition, workPath);
+
+        // Set link validation mode from command settings
+        if (Options is BuildSiteCommand.Settings buildSettings)
+            context.LinkValidation = buildSettings.LinkValidation;
+
         var pipeline = pipelineBuilder.Build();
         await pipeline(context);
         return context;

--- a/src/DocsTool/Pipelines/SectionCollector.cs
+++ b/src/DocsTool/Pipelines/SectionCollector.cs
@@ -46,7 +46,7 @@ public class SectionCollector
     private async Task CollectSection(Catalog catalog, ContentItem contentItem, BuildContext context)
     {
         _console.LogInformation($"Collect({contentItem})");
-        
+
         var definitionResult = await contentItem.TryParseYaml<SectionDefinition>();
 
         if (definitionResult.IsFailure)
@@ -58,7 +58,7 @@ public class SectionCollector
         }
 
         var definition = definitionResult.Value;
-        
+
         // default to doc type
         if (string.IsNullOrEmpty(definition.Type))
             definition.Type = "doc";
@@ -68,7 +68,7 @@ public class SectionCollector
 
         var sectionItems = CollectSectionItems(
             definition,
-            catalog, 
+            catalog,
             contentItem);
 
         var sectionDirectoryPath = contentItem
@@ -93,10 +93,10 @@ public class SectionCollector
 
         var contentItems = catalog.GetContentItems(
             contentItem.Version,
-            new[] {"**"},
+            new[] { "**" },
             $"{sectionDirectoryPath}/**/*");
 
-        var includes = definition.Includes ?? new[] {"**/*"};
+        var includes = definition.Includes ?? new[] { "**/*" };
         var includeGlobs = includes.Select(Glob.Parse)
             .ToList();
 

--- a/src/DocsTool/Pipelines/SiteBuilder.cs
+++ b/src/DocsTool/Pipelines/SiteBuilder.cs
@@ -7,7 +7,7 @@ namespace Tanka.DocsTool.Pipelines
     {
         private readonly SiteDefinition _definition;
 
-        private readonly Dictionary<string, Dictionary<string, Section>> _sectionsByVersion 
+        private readonly Dictionary<string, Dictionary<string, Section>> _sectionsByVersion
         = new Dictionary<string, Dictionary<string, Section>>();
 
         public SiteBuilder(SiteDefinition definition)

--- a/src/DocsTool/Result.cs
+++ b/src/DocsTool/Result.cs
@@ -32,10 +32,10 @@ namespace Tanka.DocsTool
 
         public static implicit operator Result<T>(T value) => new Result<T>(value);
         public static implicit operator Result<T>(string error) => new Result<T>(error);
-        
+
         public static Result<T> Success(T value) => new(value);
         public static Result<T> Failure(string error) => new(error);
-        
+
         public T GetValueOrDefault(T defaultValue) => IsSuccess ? _value : defaultValue;
     }
 
@@ -44,4 +44,4 @@ namespace Tanka.DocsTool
         public static Result<T> Success<T>(T value) => Result<T>.Success(value);
         public static Result<T> Failure<T>(string error) => Result<T>.Failure(error);
     }
-} 
+}

--- a/src/DocsTool/Security/ConfigurableFileSecurityFilter.cs
+++ b/src/DocsTool/Security/ConfigurableFileSecurityFilter.cs
@@ -21,15 +21,15 @@ public class ConfigurableFileSecurityFilter
     {
         _config = config ?? new FileFilterConfiguration();
         _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<ConfigurableFileSecurityFilter>.Instance;
-        
-        var regexOptions = _config.CaseSensitive 
-            ? RegexOptions.Compiled 
+
+        var regexOptions = _config.CaseSensitive
+            ? RegexOptions.Compiled
             : RegexOptions.IgnoreCase | RegexOptions.Compiled;
 
         // Initialize base security patterns
         _excludePatterns = new List<Regex>();
         _includePatterns = new List<Regex>();
-        
+
         if (_config.EnableSecurityFiltering)
         {
             InitializeDefaultSecurityPatterns(regexOptions);
@@ -62,7 +62,7 @@ public class ConfigurableFileSecurityFilter
 
         // Initialize extension and directory sets
         var comparer = _config.CaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
-        
+
         _excludeExtensions = new HashSet<string>(comparer);
         _excludeDirectories = new HashSet<string>(comparer);
         _includeDirectories = new HashSet<string>(comparer);

--- a/src/DocsTool/UI/DocsSiteRouter.cs
+++ b/src/DocsTool/UI/DocsSiteRouter.cs
@@ -1,4 +1,5 @@
-﻿using Tanka.DocsTool.Navigation;
+﻿using Tanka.DocsTool.Catalogs;
+using Tanka.DocsTool.Navigation;
 using Tanka.DocsTool.Pipelines;
 
 namespace Tanka.DocsTool.UI
@@ -31,12 +32,68 @@ namespace Tanka.DocsTool.UI
                 .WithVersion(targetSection.Version);
         }
 
+        public Xref? FullyQualify(Xref xref, BuildContext buildContext, ContentItem? contentItem = null)
+        {
+            var targetSection = Site.GetSectionByXref(xref, Section);
+
+            if (targetSection == null)
+            {
+                var message = $"Broken xref reference: {xref} - section not found";
+                if (buildContext.LinkValidation == LinkValidation.Strict)
+                    buildContext.Add(new Error(message, contentItem));
+                else
+                    buildContext.Add(new Error(message, contentItem), isWarning: true);
+                return null;
+            }
+
+            var targetItem = targetSection.GetContentItem(xref.Path);
+
+            if (targetItem == null)
+            {
+                var message = $"Broken xref reference: {xref} - content item not found";
+                if (buildContext.LinkValidation == LinkValidation.Strict)
+                    buildContext.Add(new Error(message, contentItem));
+                else
+                    buildContext.Add(new Error(message, contentItem), isWarning: true);
+                return null;
+            }
+
+            return xref
+                .WithSectionId(targetSection.Id)
+                .WithVersion(targetSection.Version);
+        }
+
         public string? GenerateRoute(Xref xref)
         {
             var targetSection = Site.GetSectionByXref(xref, Section);
 
             if (targetSection == null)
                 throw new InvalidOperationException($"Section NotFound: {xref}");
+
+            FileSystemPath path = xref.Path;
+
+            if (path.GetExtension() == ".md")
+                path = path.ChangeExtension(".html");
+
+            return targetSection.Version + "/" + targetSection.Path / path;
+        }
+
+        public string? GenerateRoute(Xref xref, BuildContext buildContext, ContentItem? contentItem = null)
+        {
+            var targetSection = Site.GetSectionByXref(xref, Section);
+
+            if (targetSection == null)
+            {
+                var message = $"Broken xref reference: {xref} - section not found";
+                if (buildContext.LinkValidation == LinkValidation.Strict)
+                    buildContext.Add(new Error(message, contentItem));
+                else
+                    buildContext.Add(new Error(message, contentItem), isWarning: true);
+
+                // Generate placeholder link for relaxed mode
+                var sanitizedXref = xref.ToString().Replace(":", "-").Replace("/", "-").Replace("@", "-");
+                return $"#broken-xref-{sanitizedXref}";
+            }
 
             FileSystemPath path = xref.Path;
 

--- a/src/DocsTool/UI/Navigation/DisplayLink.cs
+++ b/src/DocsTool/UI/Navigation/DisplayLink.cs
@@ -2,7 +2,7 @@
 
 namespace Tanka.DocsTool.Navigation
 {
-    public readonly struct DisplayLink: IEquatable<DisplayLink>
+    public readonly struct DisplayLink : IEquatable<DisplayLink>
     {
         public DisplayLink(string? title, Link link)
         {

--- a/src/DocsTool/UI/Navigation/DisplayLinkParser.cs
+++ b/src/DocsTool/UI/Navigation/DisplayLinkParser.cs
@@ -4,10 +4,10 @@ namespace Tanka.DocsTool.Navigation
 {
     public ref struct DisplayLinkParser
     {
-        private static readonly char[] SchemeDelimiter = {':', '/', '/'};
-        private static readonly char[] Http = {'h', 't', 't', 'p'};
-        private static readonly char[] Https = {'h', 't', 't', 'p', 's'};
-        private static readonly char[] Xref = {'x', 'r', 'e', 'f'};
+        private static readonly char[] SchemeDelimiter = { ':', '/', '/' };
+        private static readonly char[] Http = { 'h', 't', 't', 'p' };
+        private static readonly char[] Https = { 'h', 't', 't', 'p', 's' };
+        private static readonly char[] Xref = { 'x', 'r', 'e', 'f' };
 
         private readonly ReadOnlySpan<char> _link;
         private int _position;

--- a/src/DocsTool/UI/Navigation/Link.cs
+++ b/src/DocsTool/UI/Navigation/Link.cs
@@ -2,7 +2,7 @@
 
 namespace Tanka.DocsTool.Navigation
 {
-    public readonly struct Link: IEquatable<Link>
+    public readonly struct Link : IEquatable<Link>
     {
         public Link(string uri)
         {

--- a/src/DocsTool/UI/Navigation/LinkParser.cs
+++ b/src/DocsTool/UI/Navigation/LinkParser.cs
@@ -8,10 +8,10 @@ namespace Tanka.DocsTool.Navigation
 {
     public ref struct LinkParser
     {
-        private static readonly char[] SchemeDelimiter = {':', '/', '/'};
-        private static readonly char[] Http = {'h', 't', 't', 'p'};
-        private static readonly char[] Https = {'h', 't', 't', 'p', 's'};
-        private static readonly char[] Xref = {'x', 'r', 'e', 'f'};
+        private static readonly char[] SchemeDelimiter = { ':', '/', '/' };
+        private static readonly char[] Http = { 'h', 't', 't', 'p' };
+        private static readonly char[] Https = { 'h', 't', 't', 'p', 's' };
+        private static readonly char[] Xref = { 'x', 'r', 'e', 'f' };
 
         private readonly ReadOnlySpan<char> _link;
         private int _position;
@@ -58,7 +58,7 @@ namespace Tanka.DocsTool.Navigation
                         version = sectionSpan.Slice(versionSeparator)
                             .TrimStart('@')
                             .ToString();
-                        
+
                         sectionId = sectionSpan.Slice(0, versionSeparator)
                             .ToString();
                     }
@@ -97,8 +97,8 @@ namespace Tanka.DocsTool.Navigation
             ReadOnlySpan<char> unread = querySpan;
             if (querySpan[0] == '?')
                 unread = unread.Slice(1);
-                
-            var result = new Dictionary<string ,string>();
+
+            var result = new Dictionary<string, string>();
             while (!unread.IsEmpty)
             {
                 var indexOfAndOrEnd = unread.IndexOf('&');

--- a/src/DocsTool/UI/Navigation/NavigationItem.cs
+++ b/src/DocsTool/UI/Navigation/NavigationItem.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 
 namespace Tanka.DocsTool.Navigation
 {
-    public readonly struct NavigationItem: IEquatable<NavigationItem>
+    public readonly struct NavigationItem : IEquatable<NavigationItem>
     {
         public NavigationItem(
-            DisplayLink link, 
+            DisplayLink link,
             IReadOnlyCollection<NavigationItem> children)
         {
             DisplayLink = link;

--- a/src/DocsTool/UI/Navigation/Xref.cs
+++ b/src/DocsTool/UI/Navigation/Xref.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace Tanka.DocsTool.Navigation
 {
-    public readonly struct Xref: IEquatable<Xref>
+    public readonly struct Xref : IEquatable<Xref>
     {
         public Xref(string? version, string? sectionId, string path, IReadOnlyDictionary<string, string>? query = null)
         {

--- a/src/DocsTool/UI/PageRenderingContext.cs
+++ b/src/DocsTool/UI/PageRenderingContext.cs
@@ -14,7 +14,7 @@ namespace Tanka.DocsTool.UI
             Page = page;
             PageHtml = pageHtml;
         }
-        
+
         public Site Site { get; }
 
         public IReadOnlyCollection<string> Versions => Site.Versions;

--- a/src/DocsTool/UI/SectionComposer.cs
+++ b/src/DocsTool/UI/SectionComposer.cs
@@ -42,10 +42,10 @@ namespace Tanka.DocsTool.UI
             {
                 var preprocessorPipe = BuildPreProcessors(section);
                 var router = new DocsSiteRouter(_site, section);
-                var renderer = await BuildMarkdownService(section, router);
+                var renderer = await BuildMarkdownService(section, router, buildContext);
 
                 var menu = await ComposeMenu(section, buildContext);
-                
+
                 await ComposeAssets(section, router, buildContext);
                 await ComposePages(section, menu, router, renderer, preprocessorPipe, buildContext);
             }
@@ -63,9 +63,9 @@ namespace Tanka.DocsTool.UI
             return builder.Build();
         }
 
-        private Task<DocsMarkdownService> BuildMarkdownService(Section section, DocsSiteRouter router)
+        private Task<DocsMarkdownService> BuildMarkdownService(Section section, DocsSiteRouter router, BuildContext buildContext)
         {
-            var context = new DocsMarkdownRenderingContext(_site, section, router);
+            var context = new DocsMarkdownRenderingContext(_site, section, router, buildContext);
             var builder = new MarkdownPipelineBuilder();
             builder.Use(new DisplayLinkExtension(context));
 
@@ -115,7 +115,7 @@ namespace Tanka.DocsTool.UI
                 .ToLowerInvariant();
 
             //todo: better management of assets
-            return new []
+            return new[]
             {
                 ".js",
                 ".css",
@@ -130,7 +130,7 @@ namespace Tanka.DocsTool.UI
             Section section,
             IReadOnlyCollection<NavigationItem> menu,
             DocsSiteRouter router,
-            DocsMarkdownService renderer, 
+            DocsMarkdownService renderer,
             Func<FileSystemPath, PipeReader, Task<PipeReader>> preprocessorPipe,
             BuildContext buildContext)
         {
@@ -227,7 +227,7 @@ namespace Tanka.DocsTool.UI
 
                     // override context so each navigation file is rendered in the context of the owning section
                     var router = new DocsSiteRouter(_site, targetSection);
-                    var renderer = new DocsMarkdownService(new DocsMarkdownRenderingContext(_site, targetSection, router));
+                    var renderer = new DocsMarkdownService(new DocsMarkdownRenderingContext(_site, targetSection, router, buildContext));
                     var builder = new NavigationBuilder(renderer, router);
                     var fileItems = builder.Add(new string[]
                         {

--- a/src/DocsTool/UI/UiBuilder.cs
+++ b/src/DocsTool/UI/UiBuilder.cs
@@ -58,7 +58,7 @@ namespace Tanka.DocsTool.UI
                         buildContext.Add(new Error($"Failed to build section '{section}': {ex.Message}"));
                         _console.LogError($"Error building section '{section}': {ex.Message}");
                     }
-                    
+
                     task.Increment(1);
                 }
 

--- a/src/DocsTool/WebSocketService.cs
+++ b/src/DocsTool/WebSocketService.cs
@@ -15,7 +15,7 @@ public class WebSocketService : IDisposable
     public async Task Handle(WebSocket webSocket, CancellationToken cancellationToken = default)
     {
         if (_disposed) return;
-        
+
         var socketId = Guid.NewGuid();
         _sockets.TryAdd(socketId, webSocket);
 
@@ -52,15 +52,15 @@ public class WebSocketService : IDisposable
     public async Task SendReload(CancellationToken cancellationToken = default)
     {
         if (_disposed || cancellationToken.IsCancellationRequested) return;
-        
+
         var message = Encoding.UTF8.GetBytes("reload");
         var socketsToRemove = new List<Guid>();
-        
+
         foreach (var kvp in _sockets)
         {
             var socketId = kvp.Key;
             var socket = kvp.Value;
-            
+
             try
             {
                 if (socket.State == WebSocketState.Open)
@@ -82,19 +82,19 @@ public class WebSocketService : IDisposable
                 break;
             }
         }
-        
+
         // Clean up invalid sockets
         foreach (var socketId in socketsToRemove)
         {
             _sockets.TryRemove(socketId, out _);
         }
     }
-    
+
     public void Dispose()
     {
         if (_disposed) return;
         _disposed = true;
-        
+
         // Close all remaining WebSocket connections
         foreach (var socket in _sockets.Values)
         {
@@ -112,7 +112,7 @@ public class WebSocketService : IDisposable
                 // Ignore exceptions during cleanup
             }
         }
-        
+
         _sockets.Clear();
     }
-} 
+}

--- a/src/FileSystem/Git/GitBranchFileSystem.cs
+++ b/src/FileSystem/Git/GitBranchFileSystem.cs
@@ -33,7 +33,7 @@ namespace Tanka.FileSystem.Git
                 throw new InvalidOperationException(
                     $"Tree '{entry.Target.Id}' at path '{path}' is not a blob");
 
-            var blob = (Blob) entry.Target;
+            var blob = (Blob)entry.Target;
 
             return new ValueTask<IReadOnlyFile?>(
                 new GitFile(path, entry, blob));
@@ -71,7 +71,7 @@ namespace Tanka.FileSystem.Git
                         yield return new GitFile(
                             gitPath / entry.Path,
                             entry,
-                            (Blob) entry.Target);
+                            (Blob)entry.Target);
                         break;
                 }
             } while (queue.Count > 0);

--- a/src/FileSystem/Git/GitFileSystem.cs
+++ b/src/FileSystem/Git/GitFileSystem.cs
@@ -2,12 +2,12 @@
 
 namespace Tanka.FileSystem.Git;
 
-public class GitFileSystemRoot: GitBranchFileSystem
+public class GitFileSystemRoot : GitBranchFileSystem
 {
     private readonly Repository _repo;
 
     public GitFileSystemRoot(Repository repository)
-        :base(repository, repository.Head)
+        : base(repository, repository.Head)
     {
         _repo = repository;
     }
@@ -30,13 +30,13 @@ public class GitFileSystemRoot: GitBranchFileSystem
 
     public static Repository DiscoverRepo(string startingPath)
     {
-    var repoRoot = Repository.Discover(startingPath);
-    if (string.IsNullOrEmpty(repoRoot))
+        var repoRoot = Repository.Discover(startingPath);
+        if (string.IsNullOrEmpty(repoRoot))
             throw new InvalidOperationException(
             $"Could not discover Git repository starting from " +
             $"path '{startingPath}'.");
 
-    return new Repository(repoRoot);
+        return new Repository(repoRoot);
     }
 
     public FileSystemPath Path => _repo.Info.Path;

--- a/src/FileSystem/IFileSystem.cs
+++ b/src/FileSystem/IFileSystem.cs
@@ -13,7 +13,7 @@ namespace Tanka.FileSystem
         public IAsyncEnumerable<IFileSystemNode> Enumerate(FileSystemPath path);
     }
 
-    public interface IFileSystem: IReadOnlyFileSystem
+    public interface IFileSystem : IReadOnlyFileSystem
     {
         public ValueTask<IFile> GetOrCreateFile(FileSystemPath path);
 
@@ -32,7 +32,7 @@ namespace Tanka.FileSystem
         Task<IDirectory?> GetDirectory(FileSystemPath path);
     }
 
-    public interface IFile: IReadOnlyFile
+    public interface IFile : IReadOnlyFile
     {
         ValueTask<Stream> OpenWrite();
     }

--- a/src/FileSystem/IFileWatcher.cs
+++ b/src/FileSystem/IFileWatcher.cs
@@ -23,4 +23,4 @@ public interface IFileWatcher : IDisposable
     void Start(IEnumerable<string> paths, Func<FileChange, Task> onChanged);
 
     void Stop();
-} 
+}

--- a/src/FileSystem/PathHelpers.cs
+++ b/src/FileSystem/PathHelpers.cs
@@ -41,7 +41,7 @@ namespace Tanka.FileSystem
                     normalizedPath = normalizedPath.Substring(2);
                 }
             }
-            
+
             // Step 4: Handle leading slashes.
             if (isUnixAbsolute)
             {
@@ -57,7 +57,7 @@ namespace Tanka.FileSystem
                 }
                 else if (firstNonSlash > 0) // Starts with multiple slashes e.g. "//foo"
                 {
-                     normalizedPath = "/" + normalizedPath.Substring(firstNonSlash);
+                    normalizedPath = "/" + normalizedPath.Substring(firstNonSlash);
                 }
                 // If firstNonSlash is 0, it means it didn't start with a slash,
                 // which contradicts isUnixAbsolute. This case should ideally not be hit
@@ -79,7 +79,7 @@ namespace Tanka.FileSystem
             string normRight = Normalize(right);
 
             if (normRight.StartsWith("/"))
-                 return normRight;
+                return normRight;
 
             if (normLeft.EndsWith("/"))
                 return normLeft + normRight;

--- a/src/FileSystem/PhysicalFileSystem.cs
+++ b/src/FileSystem/PhysicalFileSystem.cs
@@ -103,7 +103,7 @@ namespace Tanka.FileSystem
 
             if (Directory.Exists(fullPath))
                 Directory.Delete(fullPath, true);
-            
+
             return Task.CompletedTask;
         }
 

--- a/src/FileSystem/PhysicalFileWatcher.cs
+++ b/src/FileSystem/PhysicalFileWatcher.cs
@@ -97,4 +97,4 @@ public class PhysicalFileWatcher : IFileWatcher
     {
         Stop();
     }
-} 
+}

--- a/tests/DocsTool.Tests/Async.cs
+++ b/tests/DocsTool.Tests/Async.cs
@@ -18,7 +18,7 @@ namespace Tanka.DocsTool.Tests
         {
             var list = new List<T>();
 
-            await foreach(var item in enumerable)
+            await foreach (var item in enumerable)
                 list.Add(item);
 
             return list;

--- a/tests/DocsTool.Tests/DevCommandFacts.cs
+++ b/tests/DocsTool.Tests/DevCommandFacts.cs
@@ -1,9 +1,9 @@
-using Spectre.Console.Testing;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Spectre.Console.Testing;
 using Tanka.DocsTool.Definitions;
 using Tanka.DocsTool.UI;
 using Xunit;
@@ -80,4 +80,4 @@ public class DevCommandFacts
             File.Delete(tempFile);
         }
     }
-} 
+}

--- a/tests/DocsTool.Tests/Markdown/DocsMarkdownServiceFacts.cs
+++ b/tests/DocsTool.Tests/Markdown/DocsMarkdownServiceFacts.cs
@@ -14,7 +14,7 @@ namespace Tanka.DocsTool.Tests.Markdown
         {
             // Given - Create a DocsMarkdownService
             var service = new DocsMarkdownService(new Markdig.MarkdownPipelineBuilder());
-            
+
             // Create markdown content with emojis (reproducing the original issue)
             var markdownContent = @"---
 title: Test Page
@@ -33,32 +33,32 @@ Content includes:
             // Create input stream (simulating processedStream in PageComposer)
             await using var inputStream = new MemoryStream(Encoding.UTF8.GetBytes(markdownContent));
             await using var outputStream = new MemoryStream();
-            
+
             // When - Call RenderPage (this should reproduce the "Cannot access a closed Stream" error)
             var exception = await Record.ExceptionAsync(async () =>
             {
                 await service.RenderPage(inputStream, outputStream);
             });
-            
+
             // Then - Should not throw any exception
             Assert.Null(exception);
-            
+
             // Verify output was generated
             Assert.True(outputStream.Length > 0);
-            
+
             // Verify we can still read from the input stream after RenderPage
             inputStream.Position = 0;
             using var reader = new StreamReader(inputStream, Encoding.UTF8);
             var content = await reader.ReadToEndAsync();
             Assert.Contains("Test Page", content);
         }
-        
+
         [Fact]
         public async Task RenderPage_SimulatePageComposerScenario_ShouldHandleStreamLifetime()
         {
             // Given - Simulate the exact scenario from PageComposer.ComposePartialHtmlPage
             var service = new DocsMarkdownService(new Markdig.MarkdownPipelineBuilder());
-            
+
             var markdownContent = @"---
 title: Architecture Overview
 ---
@@ -73,13 +73,13 @@ System design includes:
 
             Exception? caughtException = null;
             string contentPreview = "";
-            
+
             // When - Simulate the exact flow from PageComposer
             await using var processedStream = new MemoryStream(Encoding.UTF8.GetBytes(markdownContent));
             processedStream.Position = 0;
-            
+
             await using var outputStream = new MemoryStream();
-            
+
             try
             {
                 var frontmatter = await service.RenderPage(processedStream, outputStream);
@@ -90,7 +90,7 @@ System design includes:
             catch (Exception e)
             {
                 caughtException = e;
-                
+
                 // Simulate the error handling code from PageComposer that tries to read the stream
                 try
                 {
@@ -107,11 +107,11 @@ System design includes:
                     contentPreview = $"[Debug failed: {debugEx.Message}]";
                 }
             }
-            
+
             // Then - Should not have any exception
             if (caughtException != null)
             {
-                Assert.True(false, $"Unexpected exception: {caughtException.Message}. Content preview: {contentPreview}");
+                Assert.Fail($"Unexpected exception: {caughtException.Message}. Content preview: {contentPreview}");
             }
         }
     }

--- a/tests/DocsTool.Tests/Pipelines/AugmentFilesSectionsFacts.cs
+++ b/tests/DocsTool.Tests/Pipelines/AugmentFilesSectionsFacts.cs
@@ -80,7 +80,7 @@ namespace Tanka.DocsTool.Tests.Pipelines
 
             var sectionDirectory = Substitute.For<IDirectory>();
             _fileSystem.GetDirectory(Arg.Any<FileSystemPath>()).Returns(Task.FromResult<IDirectory?>(sectionDirectory));
-            
+
             var mockFile = Substitute.For<IReadOnlyFile>();
             mockFile.Path.Returns(new FileSystemPath("test.md"));
             sectionDirectory.Enumerate().Returns(CreateAsyncEnumerable(mockFile));

--- a/tests/DocsTool.Tests/Pipelines/CollectSectionsFacts.cs
+++ b/tests/DocsTool.Tests/Pipelines/CollectSectionsFacts.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace Tanka.DocsTool.Tests.Pipelines
 {
-    public class CollectSectionsFacts: IDisposable
+    public class CollectSectionsFacts : IDisposable
     {
         public CollectSectionsFacts()
         {
@@ -41,7 +41,7 @@ namespace Tanka.DocsTool.Tests.Pipelines
             });
 
             _aggregator = new ContentAggregator(
-                site, 
+                site,
                 git,
                 new PhysicalFileSystem(root),
                 new MimeDbClassifier(),
@@ -57,8 +57,9 @@ namespace Tanka.DocsTool.Tests.Pipelines
         [Fact]
         public Task From_root_of_the_path()
         {
-            return  _console.Progress()
-                .StartAsync(async progress => {
+            return _console.Progress()
+                .StartAsync(async progress =>
+                {
                     /* Given */
                     var collector = new SectionCollector(_console, true);
                     var root = GetRepoRootWithoutDotGit();

--- a/tests/DocsTool.Tests/Pipelines/ExecutorFacts.cs
+++ b/tests/DocsTool.Tests/Pipelines/ExecutorFacts.cs
@@ -19,7 +19,7 @@ namespace Tanka.DocsTool.Tests.Pipelines
 
         public string GitRootPath { get; set; }
 
-        [Fact(Skip ="Refactor so this runs on memory")]
+        [Fact(Skip = "Refactor so this runs on memory")]
         public async Task Execute()
         {
             /* Given */
@@ -32,7 +32,7 @@ namespace Tanka.DocsTool.Tests.Pipelines
                 {
                     ["HEAD"] = new BranchDefinition()
                     {
-                        InputPath = new[] { "ui-bundle", "docs-v2", "src"}
+                        InputPath = new[] { "ui-bundle", "docs-v2", "src" }
                     }
                 },
                 Tags = new Dictionary<string, BranchDefinition>()
@@ -58,7 +58,7 @@ namespace Tanka.DocsTool.Tests.Pipelines
                 );
 
             await executor.Execute(new PipelineBuilder(services)
-                .UseDefault(), 
+                .UseDefault(),
                 site,
                 GitRootPath);
 

--- a/tests/DocsTool.Tests/Security/FileSecurityFilterFacts.cs
+++ b/tests/DocsTool.Tests/Security/FileSecurityFilterFacts.cs
@@ -107,7 +107,7 @@ public class FileSecurityFilterFacts
         /* Given */
         var config = new FileFilterConfiguration();
         config.ExcludePatterns.Add(@".*\.secret$");
-        
+
         var filter = new ConfigurableFileSecurityFilter(config);
         var secretFile = CreateMockFile("data.secret");
         var normalFile = CreateMockFile("data.txt");
@@ -127,7 +127,7 @@ public class FileSecurityFilterFacts
         /* Given */
         var config = new FileFilterConfiguration();
         config.IncludePatterns.Add(@"allowed\.env$");
-        
+
         var filter = new ConfigurableFileSecurityFilter(config);
         var allowedEnvFile = CreateMockFile("allowed.env");
         var normalEnvFile = CreateMockFile(".env");
@@ -145,8 +145,8 @@ public class FileSecurityFilterFacts
     public void ConfigurableFilter_WithSecurityDisabled_AllowsAllFiles()
     {
         /* Given */
-        var config = new FileFilterConfiguration 
-        { 
+        var config = new FileFilterConfiguration
+        {
             EnableSecurityFiltering = false,
             IncludeHiddenFiles = true // Need to also allow hidden files to test .env
         };
@@ -179,8 +179,8 @@ public class FileSecurityFilterFacts
     public void ConfigurableFilter_WithHiddenFilesEnabled_AllowsHiddenFiles()
     {
         /* Given */
-        var config = new FileFilterConfiguration 
-        { 
+        var config = new FileFilterConfiguration
+        {
             IncludeHiddenFiles = true,
             EnableSecurityFiltering = false // Disable security to focus on hidden file behavior
         };
@@ -201,7 +201,7 @@ public class FileSecurityFilterFacts
         var config = new FileFilterConfiguration();
         config.ExcludeExtensions.Add("custom");
         config.ExcludeExtensions.Add(".special");
-        
+
         var filter = new ConfigurableFileSecurityFilter(config);
         var customFile = CreateMockFile("file.custom");
         var specialFile = CreateMockFile("file.special");
@@ -225,7 +225,7 @@ public class FileSecurityFilterFacts
         var config = new FileFilterConfiguration();
         config.ExcludeDirectories.Add("custom-build");
         config.IncludeDirectories.Add("important-secrets"); // Should override exclusion
-        
+
         var filter = new ConfigurableFileSecurityFilter(config);
         var customBuildDir = CreateMockDirectory("custom-build");
         var importantSecretsDir = CreateMockDirectory("important-secrets");

--- a/tests/DocsTool.Tests/UI/Navigation/NavigationBuilderFacts.cs
+++ b/tests/DocsTool.Tests/UI/Navigation/NavigationBuilderFacts.cs
@@ -27,7 +27,7 @@ namespace Tanka.DocsTool.Tests.UI.Navigation
             source.Path.Returns(new FileSystemPath(""));
 
             var section = new Section(new ContentItem(
-                    source, "tanka/section" , Substitute.For<IReadOnlyFile>()),
+                    source, "tanka/section", Substitute.For<IReadOnlyFile>()),
                 new SectionDefinition()
                 {
                     Id = "sectionId"
@@ -41,17 +41,18 @@ namespace Tanka.DocsTool.Tests.UI.Navigation
                 });
 
             var site = new Site(
-                new SiteDefinition(), 
+                new SiteDefinition(),
                 new Dictionary<string, Dictionary<string, Section>>()
-            {
-                ["TEST"] = new Dictionary<string, Section>()
                 {
-                    [section.Id] = section
-                }
-            });
+                    ["TEST"] = new Dictionary<string, Section>()
+                    {
+                        [section.Id] = section
+                    }
+                });
             _router = new DocsSiteRouter(site, section);
+            var buildContext = new BuildContext(new SiteDefinition(), "/test");
             _mdService = new DocsMarkdownService(
-                new DocsMarkdownRenderingContext(site, section, _router));
+                new DocsMarkdownRenderingContext(site, section, _router, buildContext));
 
             _sut = new NavigationBuilder(_mdService, _router);
         }
@@ -71,7 +72,7 @@ namespace Tanka.DocsTool.Tests.UI.Navigation
 ";
 
             /* When */
-            var menu = _sut.Add(new [] 
+            var menu = _sut.Add(new[]
             {
                 md
             }).Build();

--- a/tests/DocsTool.Tests/XrefLongFilenameIntegrationFacts.cs
+++ b/tests/DocsTool.Tests/XrefLongFilenameIntegrationFacts.cs
@@ -19,85 +19,85 @@ namespace Tanka.DocsTool.Tests
         {
             /* Given - Create a site with a section containing a long filename */
             var longFilename = "Chibi.Ui.Benchmarks.Graphics.Basic.BasicDrawingBenchmarks-report-github.md";
-            
+
             // Create source and content items
             var source = CreateMockContentSource();
             var contentItems = new Dictionary<FileSystemPath, ContentItem>
             {
                 { new FileSystemPath(longFilename), new ContentItem(source, "text/markdown", Substitute.For<IReadOnlyFile>()) }
             };
-            
+
             // Create a section with the content item
             var section = new Section(
                 new ContentItem(source, "tanka/section", Substitute.For<IReadOnlyFile>()),
                 new SectionDefinition() { Id = "default" },
                 contentItems
             );
-            
+
             // Create a site with the section
             var versionSections = new Dictionary<string, Section> { { "default", section } };
             var allSections = new Dictionary<string, Dictionary<string, Section>> { { "TEST", versionSections } };
             var site = new Site(new SiteDefinition(), allSections);
-            
+
             // Create the router
             var router = new DocsSiteRouter(site, section);
-            
+
             /* When - Try to resolve the XREF link */
             var xref = new Tanka.DocsTool.Navigation.Xref(
                 version: null,
                 sectionId: null,
                 path: longFilename
             );
-            
+
             /* Then - Should not throw exception */
             var exception = Record.Exception(() => router.FullyQualify(xref));
             Assert.Null(exception);
         }
-        
+
         [Fact]
         public void DocsSiteRouter_ShouldThrowNotFoundForMissingLongFilename()
         {
             /* Given - Create a site without the missing filename */
             var longFilename = "Chibi.Ui.Benchmarks.Graphics.Basic.BasicDrawingBenchmarks-report-github.md";
             var missingFilename = "Different.Long.Filename.That.Does.Not.Exist.md";
-            
+
             // Create source and content items (only the existing file)
             var source = CreateMockContentSource();
             var contentItems = new Dictionary<FileSystemPath, ContentItem>
             {
                 { new FileSystemPath(longFilename), new ContentItem(source, "text/markdown", Substitute.For<IReadOnlyFile>()) }
             };
-            
+
             // Create a section with only the existing content item
             var section = new Section(
                 new ContentItem(source, "tanka/section", Substitute.For<IReadOnlyFile>()),
                 new SectionDefinition() { Id = "default" },
                 contentItems
             );
-            
+
             // Create a site with the section
             var versionSections = new Dictionary<string, Section> { { "default", section } };
             var allSections = new Dictionary<string, Dictionary<string, Section>> { { "TEST", versionSections } };
             var site = new Site(new SiteDefinition(), allSections);
-            
+
             // Create the router
             var router = new DocsSiteRouter(site, section);
-            
+
             /* When - Try to resolve a missing XREF link */
             var xref = new Tanka.DocsTool.Navigation.Xref(
                 version: null,
                 sectionId: null,
                 path: missingFilename
             );
-            
+
             /* Then - Should throw NotFound exception */
-            var exception = Assert.Throws<InvalidOperationException>(() => 
+            var exception = Assert.Throws<InvalidOperationException>(() =>
                 router.FullyQualify(xref));
-            
+
             Assert.Contains("NotFound", exception.Message);
             Assert.Contains(missingFilename, exception.Message);
         }
-        
+
         [Theory]
         [InlineData("Very.Long.Namespace.Class.Method.Benchmark-Results-Report.md")]
         [InlineData("Another.Really.Long.ClassName.WithManySegments.AndNumbers123.AndMore-final-report.md")]
@@ -111,69 +111,69 @@ namespace Tanka.DocsTool.Tests
             {
                 { new FileSystemPath(filename), new ContentItem(source, "text/markdown", Substitute.For<IReadOnlyFile>()) }
             };
-            
+
             var section = new Section(
                 new ContentItem(source, "tanka/section", Substitute.For<IReadOnlyFile>()),
                 new SectionDefinition() { Id = "default" },
                 contentItems
             );
-            
+
             var versionSections = new Dictionary<string, Section> { { "default", section } };
             var allSections = new Dictionary<string, Dictionary<string, Section>> { { "TEST", versionSections } };
             var site = new Site(new SiteDefinition(), allSections);
             var router = new DocsSiteRouter(site, section);
-            
+
             /* When - Try to resolve the XREF link */
             var xref = new Tanka.DocsTool.Navigation.Xref(
                 version: null,
                 sectionId: null,
                 path: filename
             );
-            
+
             /* Then - Should not throw exception */
             var exception = Record.Exception(() => router.FullyQualify(xref));
             Assert.Null(exception);
         }
-        
+
         [Fact]
         public void FileSystemPath_ShouldHandleLongFilenames()
         {
             /* Given */
             var longFilename = "Chibi.Ui.Benchmarks.Graphics.Basic.BasicDrawingBenchmarks-report-github.md";
-            
+
             /* When */
             var path = new FileSystemPath(longFilename);
-            
+
             /* Then */
             Assert.Equal(longFilename, path.ToString());
             Assert.Equal(longFilename, (string)path);
         }
-        
+
         [Fact]
         public void FileSystemPath_EqualityWithLongFilenames()
         {
             /* Given */
             var longFilename = "Chibi.Ui.Benchmarks.Graphics.Basic.BasicDrawingBenchmarks-report-github.md";
-            
+
             /* When */
             var path1 = new FileSystemPath(longFilename);
             var path2 = new FileSystemPath(longFilename);
             var path3 = new FileSystemPath("different.md");
-            
+
             /* Then */
             Assert.Equal(path1, path2);
             Assert.NotEqual(path1, path3);
-            
+
             // Test dictionary key behavior
             var dict = new Dictionary<FileSystemPath, string>
             {
                 { path1, "test" }
             };
-            
+
             Assert.True(dict.ContainsKey(path2));
             Assert.False(dict.ContainsKey(path3));
         }
-        
+
         private static IContentSource CreateMockContentSource()
         {
             var source = Substitute.For<IContentSource>();

--- a/tests/FileSystem.Tests/Git/GitFileSystemFacts.cs
+++ b/tests/FileSystem.Tests/Git/GitFileSystemFacts.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Tanka.FileSystem.Tests.Git
 {
-    public class GitFileSystemFacts: IDisposable
+    public class GitFileSystemFacts : IDisposable
     {
         public readonly GitFileSystemRoot RootFs;
 
@@ -28,7 +28,7 @@ namespace Tanka.FileSystem.Tests.Git
             /* Given */
             var fs = RootFs.Head();
             var canEnumerate = false;
-            
+
             /* When */
             await foreach (var node in fs.Enumerate(""))
             {


### PR DESCRIPTION
## Summary
- Implements configurable link validation with `--link-validation` CLI parameter
- Adds Strict mode (default for build): errors and non-zero exit codes for broken xrefs
- Adds Relaxed mode (default for dev): warnings but continues build for broken xrefs
- Updates markdown processing pipeline to handle broken xrefs gracefully
- Adds console extension methods for consistent error/warning styling

## Changes Made
- **LinkValidation enum**: Defines Strict and Relaxed validation modes
- **CLI parameters**: Added `--link-validation` to both build and dev commands with appropriate defaults
- **DocsSiteRouter**: Enhanced with validation-aware methods that collect errors instead of throwing exceptions
- **Markdown pipeline**: Updated to pass BuildContext through rendering chain for validation support
- **Console extensions**: Added consistent styling methods for errors and warnings
- **Broken xref handling**: Generates placeholder links in relaxed mode with CSS classes for styling

## Behavior
- **Build command**: Defaults to strict mode, fails build on broken xrefs
- **Dev command**: Defaults to relaxed mode, shows warnings but continues for better development experience
- **File watcher rebuilds**: Uses relaxed mode to avoid interrupting development workflow

## Test Plan
- [x] Build succeeds with both strict and relaxed modes
- [x] All existing tests pass
- [x] Code formatting follows project standards
- [x] CLI parameters work correctly with Spectre.Console

Fixes #253

🤖 Generated with [Claude Code](https://claude.ai/code)